### PR TITLE
Window interval parser added

### DIFF
--- a/sqlparser_bench/Cargo.toml
+++ b/sqlparser_bench/Cargo.toml
@@ -11,5 +11,5 @@ sqlparser = { path = "../" }
 criterion = "0.4"
 
 [[bench]]
-name = "sqlparser_bench"
 harness = false
+name = "sqlparser_bench"

--- a/sqlparser_bench/Cargo.toml
+++ b/sqlparser_bench/Cargo.toml
@@ -11,5 +11,5 @@ sqlparser = { path = "../" }
 criterion = "0.4"
 
 [[bench]]
-harness = false
 name = "sqlparser_bench"
+harness = false

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -205,73 +205,6 @@ impl fmt::Display for JsonOperator {
     }
 }
 
-/// INTERVAL literals, roughly in the following format:
-/// `INTERVAL '<value>' [ <leading_field> [ (<leading_precision>) ] ]
-/// [ TO <last_field> [ (<fractional_seconds_precision>) ] ]`,
-/// e.g. `INTERVAL '123:45.67' MINUTE(3) TO SECOND(2)`.
-///
-/// The parser does not validate the `<value>`, nor does it ensure
-/// that the `<leading_field>` units >= the units in `<last_field>`,
-/// so the user will have to reject intervals like `HOUR TO YEAR`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Interval {
-    pub value: Box<Expr>,
-    pub leading_field: Option<DateTimeField>,
-    pub leading_precision: Option<u64>,
-    pub last_field: Option<DateTimeField>,
-    /// The seconds precision can be specified in SQL source as
-    /// `INTERVAL '__' SECOND(_, x)` (in which case the `leading_field`
-    /// will be `Second` and the `last_field` will be `None`),
-    /// or as `__ TO SECOND(x)`.
-    pub fractional_seconds_precision: Option<u64>,
-}
-
-impl fmt::Display for Interval {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Interval {
-                value,
-                leading_field: Some(DateTimeField::Second),
-                leading_precision: Some(leading_precision),
-                last_field,
-                fractional_seconds_precision: Some(fractional_seconds_precision),
-            } => {
-                // When the leading field is SECOND, the parser guarantees that
-                // the last field is None.
-                assert!(last_field.is_none());
-                write!(
-                    f,
-                    "INTERVAL {} SECOND ({}, {})",
-                    value, leading_precision, fractional_seconds_precision
-                )
-            }
-            Interval {
-                value,
-                leading_field,
-                leading_precision,
-                last_field,
-                fractional_seconds_precision,
-            } => {
-                write!(f, "INTERVAL {}", value)?;
-                if let Some(leading_field) = leading_field {
-                    write!(f, " {}", leading_field)?;
-                }
-                if let Some(leading_precision) = leading_precision {
-                    write!(f, " ({})", leading_precision)?;
-                }
-                if let Some(last_field) = last_field {
-                    write!(f, " TO {}", last_field)?;
-                }
-                if let Some(fractional_seconds_precision) = fractional_seconds_precision {
-                    write!(f, " ({})", fractional_seconds_precision)?;
-                }
-                Ok(())
-            }
-        }
-    }
-}
-
 /// An SQL expression of any type.
 ///
 /// The parser does not distinguish between expressions of different types
@@ -477,8 +410,25 @@ pub enum Expr {
     ArrayIndex { obj: Box<Expr>, indexes: Vec<Expr> },
     /// An array expression e.g. `ARRAY[1, 2]`
     Array(Array),
-    /// INTERVAL literals, such as `INTERVAL '1 DAY'`
-    Interval(Interval),
+    /// INTERVAL literals, roughly in the following format:
+    /// `INTERVAL '<value>' [ <leading_field> [ (<leading_precision>) ] ]
+    /// [ TO <last_field> [ (<fractional_seconds_precision>) ] ]`,
+    /// e.g. `INTERVAL '123:45.67' MINUTE(3) TO SECOND(2)`.
+    ///
+    /// The parser does not validate the `<value>`, nor does it ensure
+    /// that the `<leading_field>` units >= the units in `<last_field>`,
+    /// so the user will have to reject intervals like `HOUR TO YEAR`.
+    Interval {
+        value: Box<Expr>,
+        leading_field: Option<DateTimeField>,
+        leading_precision: Option<u64>,
+        last_field: Option<DateTimeField>,
+        /// The seconds precision can be specified in SQL source as
+        /// `INTERVAL '__' SECOND(_, x)` (in which case the `leading_field`
+        /// will be `Second` and the `last_field` will be `None`),
+        /// or as `__ TO SECOND(x)`.
+        fractional_seconds_precision: Option<u64>,
+    },
 }
 
 impl fmt::Display for Expr {
@@ -791,8 +741,43 @@ impl fmt::Display for Expr {
             } => {
                 write!(f, "{} AT TIME ZONE '{}'", timestamp, time_zone)
             }
-            Expr::Interval(interval) => {
-                write!(f, "{}", interval)
+            Expr::Interval {
+                value,
+                leading_field: Some(DateTimeField::Second),
+                leading_precision: Some(leading_precision),
+                last_field,
+                fractional_seconds_precision: Some(fractional_seconds_precision),
+            } => {
+                // When the leading field is SECOND, the parser guarantees that
+                // the last field is None.
+                assert!(last_field.is_none());
+                write!(
+                    f,
+                    "INTERVAL {} SECOND ({}, {})",
+                    value, leading_precision, fractional_seconds_precision
+                )
+            }
+            Expr::Interval {
+                value,
+                leading_field,
+                leading_precision,
+                last_field,
+                fractional_seconds_precision,
+            } => {
+                write!(f, "INTERVAL {}", value)?;
+                if let Some(leading_field) = leading_field {
+                    write!(f, " {}", leading_field)?;
+                }
+                if let Some(leading_precision) = leading_precision {
+                    write!(f, " ({})", leading_precision)?;
+                }
+                if let Some(last_field) = last_field {
+                    write!(f, " TO {}", last_field)?;
+                }
+                if let Some(fractional_seconds_precision) = fractional_seconds_precision {
+                    write!(f, " ({})", fractional_seconds_precision)?;
+                }
+                Ok(())
             }
         }
     }
@@ -918,7 +903,7 @@ pub enum RangeBounds {
     /// Number literal, e.g `1`, `1.1`
     Number(String),
     /// Interval, such as `INTERVAL '1 DAY' `
-    Interval(Interval),
+    Interval(Expr),
 }
 
 impl fmt::Display for RangeBounds {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -205,6 +205,73 @@ impl fmt::Display for JsonOperator {
     }
 }
 
+/// INTERVAL literals, roughly in the following format:
+/// `INTERVAL '<value>' [ <leading_field> [ (<leading_precision>) ] ]
+/// [ TO <last_field> [ (<fractional_seconds_precision>) ] ]`,
+/// e.g. `INTERVAL '123:45.67' MINUTE(3) TO SECOND(2)`.
+///
+/// The parser does not validate the `<value>`, nor does it ensure
+/// that the `<leading_field>` units >= the units in `<last_field>`,
+/// so the user will have to reject intervals like `HOUR TO YEAR`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Interval {
+    pub value: Box<Expr>,
+    pub leading_field: Option<DateTimeField>,
+    pub leading_precision: Option<u64>,
+    pub last_field: Option<DateTimeField>,
+    /// The seconds precision can be specified in SQL source as
+    /// `INTERVAL '__' SECOND(_, x)` (in which case the `leading_field`
+    /// will be `Second` and the `last_field` will be `None`),
+    /// or as `__ TO SECOND(x)`.
+    pub fractional_seconds_precision: Option<u64>,
+}
+
+impl fmt::Display for Interval {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Interval {
+                value,
+                leading_field: Some(DateTimeField::Second),
+                leading_precision: Some(leading_precision),
+                last_field,
+                fractional_seconds_precision: Some(fractional_seconds_precision),
+            } => {
+                // When the leading field is SECOND, the parser guarantees that
+                // the last field is None.
+                assert!(last_field.is_none());
+                write!(
+                    f,
+                    "INTERVAL {} SECOND ({}, {})",
+                    value, leading_precision, fractional_seconds_precision
+                )
+            }
+            Interval {
+                value,
+                leading_field,
+                leading_precision,
+                last_field,
+                fractional_seconds_precision,
+            } => {
+                write!(f, "INTERVAL {}", value)?;
+                if let Some(leading_field) = leading_field {
+                    write!(f, " {}", leading_field)?;
+                }
+                if let Some(leading_precision) = leading_precision {
+                    write!(f, " ({})", leading_precision)?;
+                }
+                if let Some(last_field) = last_field {
+                    write!(f, " TO {}", last_field)?;
+                }
+                if let Some(fractional_seconds_precision) = fractional_seconds_precision {
+                    write!(f, " ({})", fractional_seconds_precision)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
 /// An SQL expression of any type.
 ///
 /// The parser does not distinguish between expressions of different types
@@ -410,25 +477,8 @@ pub enum Expr {
     ArrayIndex { obj: Box<Expr>, indexes: Vec<Expr> },
     /// An array expression e.g. `ARRAY[1, 2]`
     Array(Array),
-    /// INTERVAL literals, roughly in the following format:
-    /// `INTERVAL '<value>' [ <leading_field> [ (<leading_precision>) ] ]
-    /// [ TO <last_field> [ (<fractional_seconds_precision>) ] ]`,
-    /// e.g. `INTERVAL '123:45.67' MINUTE(3) TO SECOND(2)`.
-    ///
-    /// The parser does not validate the `<value>`, nor does it ensure
-    /// that the `<leading_field>` units >= the units in `<last_field>`,
-    /// so the user will have to reject intervals like `HOUR TO YEAR`.
-    Interval {
-        value: Box<Expr>,
-        leading_field: Option<DateTimeField>,
-        leading_precision: Option<u64>,
-        last_field: Option<DateTimeField>,
-        /// The seconds precision can be specified in SQL source as
-        /// `INTERVAL '__' SECOND(_, x)` (in which case the `leading_field`
-        /// will be `Second` and the `last_field` will be `None`),
-        /// or as `__ TO SECOND(x)`.
-        fractional_seconds_precision: Option<u64>,
-    },
+    /// INTERVAL literals, such as `INTERVAL '1 DAY'`
+    Interval(Interval),
 }
 
 impl fmt::Display for Expr {
@@ -741,43 +791,8 @@ impl fmt::Display for Expr {
             } => {
                 write!(f, "{} AT TIME ZONE '{}'", timestamp, time_zone)
             }
-            Expr::Interval {
-                value,
-                leading_field: Some(DateTimeField::Second),
-                leading_precision: Some(leading_precision),
-                last_field,
-                fractional_seconds_precision: Some(fractional_seconds_precision),
-            } => {
-                // When the leading field is SECOND, the parser guarantees that
-                // the last field is None.
-                assert!(last_field.is_none());
-                write!(
-                    f,
-                    "INTERVAL {} SECOND ({}, {})",
-                    value, leading_precision, fractional_seconds_precision
-                )
-            }
-            Expr::Interval {
-                value,
-                leading_field,
-                leading_precision,
-                last_field,
-                fractional_seconds_precision,
-            } => {
-                write!(f, "INTERVAL {}", value)?;
-                if let Some(leading_field) = leading_field {
-                    write!(f, " {}", leading_field)?;
-                }
-                if let Some(leading_precision) = leading_precision {
-                    write!(f, " ({})", leading_precision)?;
-                }
-                if let Some(last_field) = last_field {
-                    write!(f, " TO {}", last_field)?;
-                }
-                if let Some(fractional_seconds_precision) = fractional_seconds_precision {
-                    write!(f, " ({})", fractional_seconds_precision)?;
-                }
-                Ok(())
+            Expr::Interval(interval) => {
+                write!(f, "{}", interval)
             }
         }
     }
@@ -879,9 +894,9 @@ pub enum WindowFrameBound {
     /// `CURRENT ROW`
     CurrentRow,
     /// `<N> PRECEDING` or `UNBOUNDED PRECEDING`
-    Preceding(Option<u64>),
+    Preceding(Option<RangeBounds>),
     /// `<N> FOLLOWING` or `UNBOUNDED FOLLOWING`.
-    Following(Option<u64>),
+    Following(Option<RangeBounds>),
 }
 
 impl fmt::Display for WindowFrameBound {
@@ -892,6 +907,27 @@ impl fmt::Display for WindowFrameBound {
             WindowFrameBound::Following(None) => f.write_str("UNBOUNDED FOLLOWING"),
             WindowFrameBound::Preceding(Some(n)) => write!(f, "{} PRECEDING", n),
             WindowFrameBound::Following(Some(n)) => write!(f, "{} FOLLOWING", n),
+        }
+    }
+}
+
+/// Specifies offset values in the [WindowFrameBound]'s `Preceding` and `Following`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum RangeBounds {
+    /// Number literal, e.g `1`, `1.1`
+    Number(String),
+    /// Interval, such as `INTERVAL '1 DAY' `
+    Interval(Interval),
+}
+
+impl fmt::Display for RangeBounds {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RangeBounds::Number(s) => write!(f, "{}", s),
+            RangeBounds::Interval(interval) => {
+                write!(f, "{}", interval)
+            }
         }
     }
 }
@@ -2668,7 +2704,7 @@ impl fmt::Display for CloseCursor {
 pub struct Function {
     pub name: ObjectName,
     pub args: Vec<FunctionArg>,
-    pub over: Option<WindowSpec>,
+    pub over: Option<Box<WindowSpec>>,
     // aggregate functions may specify eg `COUNT(DISTINCT x)`
     pub distinct: bool,
     // Some functions must be called without trailing parentheses, for example Postgres

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -402,7 +402,7 @@ impl<'a> Parser<'a> {
         // expression that should parse as the column name "date".
         return_ok_if_some!(self.maybe_parse(|parser| {
             match parser.parse_data_type()? {
-                DataType::Interval => parser.parse_interval(),
+                DataType::Interval => Ok(Expr::Interval(parser.parse_interval()?)),
                 // PostgreSQL allows almost any identifier to be used as custom data type name,
                 // and we support that in `parse_data_type()`. But unlike Postgres we don't
                 // have a list of globally reserved keywords (since they vary across dialects),
@@ -455,7 +455,7 @@ impl<'a> Parser<'a> {
                 Keyword::SUBSTRING => self.parse_substring_expr(),
                 Keyword::OVERLAY => self.parse_overlay_expr(),
                 Keyword::TRIM => self.parse_trim_expr(),
-                Keyword::INTERVAL => self.parse_interval(),
+                Keyword::INTERVAL => Ok(Expr::Interval(self.parse_interval()?)),
                 Keyword::LISTAGG => self.parse_listagg_expr(),
                 // Treat ARRAY[1,2,3] as an array [1,2,3], otherwise try as subquery or a function call
                 Keyword::ARRAY if self.peek_token() == Token::LBracket => {
@@ -621,7 +621,7 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
-
+        let over = over.map(Box::new);
         Ok(Expr::Function(Function {
             name,
             args,
@@ -683,7 +683,7 @@ impl<'a> Parser<'a> {
             let rows = if self.parse_keyword(Keyword::UNBOUNDED) {
                 None
             } else {
-                Some(self.parse_literal_uint()?)
+                Some(self.parse_range_values()?)
             };
             if self.parse_keyword(Keyword::PRECEDING) {
                 Ok(WindowFrameBound::Preceding(rows))
@@ -1110,7 +1110,7 @@ impl<'a> Parser<'a> {
     ///   7. (MySql and BigQuey only):`INTERVAL 1 DAY`
     ///
     /// Note that we do not currently attempt to parse the quoted value.
-    pub fn parse_interval(&mut self) -> Result<Expr, ParserError> {
+    pub fn parse_interval(&mut self) -> Result<Interval, ParserError> {
         // The SQL standard allows an optional sign before the value string, but
         // it is not clear if any implementations support that syntax, so we
         // don't currently try to parse it. (The sign can instead be included
@@ -1185,7 +1185,7 @@ impl<'a> Parser<'a> {
                 }
             };
 
-        Ok(Expr::Interval {
+        Ok(Interval {
             value: Box::new(value),
             leading_field,
             leading_precision,
@@ -3298,6 +3298,42 @@ impl<'a> Parser<'a> {
                 ParserError::ParserError(format!("Could not parse '{}' as u64: {}", s, e))
             }),
             unexpected => self.expected("literal int", unexpected),
+        }
+    }
+
+    /// Parse a literal inside window frames such as 1 PRECEDING or '1 DAY' PRECEDING
+    pub fn parse_range_values(&mut self) -> Result<RangeBounds, ParserError> {
+        match self.peek_token() {
+            Token::Number(s, _) => {
+                // consume token Token::Number
+                self.next_token();
+                Ok(RangeBounds::Number(s))
+            }
+            Token::Word(w) => match w.keyword {
+                Keyword::INTERVAL => {
+                    // consume token Keyword::INTERVAL
+                    self.next_token();
+                    match self.parse_interval() {
+                        Ok(interval) => Ok(RangeBounds::Interval(interval)),
+                        e => Err(ParserError::ParserError(format!(
+                            "Interval is not valid {:?}",
+                            e
+                        ))),
+                    }
+                }
+                e => Err(ParserError::ParserError(format!(
+                    "Interval is not valid {:?}",
+                    e
+                ))),
+            },
+            Token::SingleQuotedString(_) => match self.parse_interval() {
+                Ok(interval) => Ok(RangeBounds::Interval(interval)),
+                e => Err(ParserError::ParserError(format!(
+                    "Interval is not valid {:?}",
+                    e
+                ))),
+            },
+            unexpected => self.expected("literal Expression", unexpected),
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -402,7 +402,7 @@ impl<'a> Parser<'a> {
         // expression that should parse as the column name "date".
         return_ok_if_some!(self.maybe_parse(|parser| {
             match parser.parse_data_type()? {
-                DataType::Interval => Ok(Expr::Interval(parser.parse_interval()?)),
+                DataType::Interval => parser.parse_interval(),
                 // PostgreSQL allows almost any identifier to be used as custom data type name,
                 // and we support that in `parse_data_type()`. But unlike Postgres we don't
                 // have a list of globally reserved keywords (since they vary across dialects),
@@ -455,7 +455,7 @@ impl<'a> Parser<'a> {
                 Keyword::SUBSTRING => self.parse_substring_expr(),
                 Keyword::OVERLAY => self.parse_overlay_expr(),
                 Keyword::TRIM => self.parse_trim_expr(),
-                Keyword::INTERVAL => Ok(Expr::Interval(self.parse_interval()?)),
+                Keyword::INTERVAL => self.parse_interval(),
                 Keyword::LISTAGG => self.parse_listagg_expr(),
                 // Treat ARRAY[1,2,3] as an array [1,2,3], otherwise try as subquery or a function call
                 Keyword::ARRAY if self.peek_token() == Token::LBracket => {
@@ -1110,7 +1110,7 @@ impl<'a> Parser<'a> {
     ///   7. (MySql and BigQuey only):`INTERVAL 1 DAY`
     ///
     /// Note that we do not currently attempt to parse the quoted value.
-    pub fn parse_interval(&mut self) -> Result<Interval, ParserError> {
+    pub fn parse_interval(&mut self) -> Result<Expr, ParserError> {
         // The SQL standard allows an optional sign before the value string, but
         // it is not clear if any implementations support that syntax, so we
         // don't currently try to parse it. (The sign can instead be included
@@ -1185,7 +1185,7 @@ impl<'a> Parser<'a> {
                 }
             };
 
-        Ok(Interval {
+        Ok(Expr::Interval {
             value: Box::new(value),
             leading_field,
             leading_precision,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1555,7 +1555,7 @@ fn parse_select_qualify() {
             left: Box::new(Expr::Function(Function {
                 name: ObjectName(vec![Ident::new("ROW_NUMBER")]),
                 args: vec![],
-                over: Some(WindowSpec {
+                over: Some(Box::new(WindowSpec {
                     partition_by: vec![Expr::Identifier(Ident::new("p"))],
                     order_by: vec![OrderByExpr {
                         expr: Expr::Identifier(Ident::new("o")),
@@ -1563,7 +1563,7 @@ fn parse_select_qualify() {
                         nulls_first: None
                     }],
                     window_frame: None
-                }),
+                })),
                 distinct: false,
                 special: false
             })),
@@ -2829,18 +2829,22 @@ fn parse_window_functions() {
                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), \
                avg(bar) OVER (ORDER BY a \
                RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING), \
+               sum(bar) OVER (ORDER BY a \
+               RANGE BETWEEN INTERVAL '1' DAY PRECEDING AND INTERVAL '1 MONTH' FOLLOWING), \
+               COUNT(*) OVER (ORDER BY a \
+               RANGE BETWEEN INTERVAL '1 DAYS' PRECEDING AND INTERVAL '1 DAY' FOLLOWING), \
                max(baz) OVER (ORDER BY a \
                ROWS UNBOUNDED PRECEDING), \
                sum(qux) OVER (ORDER BY a \
                GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING) \
                FROM foo";
     let select = verified_only_select(sql);
-    assert_eq!(5, select.projection.len());
+    assert_eq!(7, select.projection.len());
     assert_eq!(
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("row_number")]),
             args: vec![],
-            over: Some(WindowSpec {
+            over: Some(Box::new(WindowSpec {
                 partition_by: vec![],
                 order_by: vec![OrderByExpr {
                     expr: Expr::Identifier(Ident::new("dt")),
@@ -2848,7 +2852,7 @@ fn parse_window_functions() {
                     nulls_first: None,
                 }],
                 window_frame: None,
-            }),
+            })),
             distinct: false,
             special: false,
         }),
@@ -2982,20 +2986,20 @@ fn parse_interval() {
     let sql = "SELECT INTERVAL '1-1' YEAR TO MONTH";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval {
+        &Expr::Interval(Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1-1")))),
             leading_field: Some(DateTimeField::Year),
             leading_precision: None,
             last_field: Some(DateTimeField::Month),
             fractional_seconds_precision: None,
-        },
+        }),
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '01:01.01' MINUTE (5) TO SECOND (5)";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval {
+        &Expr::Interval(Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
                 "01:01.01"
             )))),
@@ -3003,53 +3007,53 @@ fn parse_interval() {
             leading_precision: Some(5),
             last_field: Some(DateTimeField::Second),
             fractional_seconds_precision: Some(5),
-        },
+        }),
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '1' SECOND (5, 4)";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval {
+        &Expr::Interval(Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1")))),
             leading_field: Some(DateTimeField::Second),
             leading_precision: Some(5),
             last_field: None,
             fractional_seconds_precision: Some(4),
-        },
+        }),
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '10' HOUR";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval {
+        &Expr::Interval(Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        },
+        }),
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL 5 DAY";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval {
+        &Expr::Interval(Interval {
             value: Box::new(Expr::Value(number("5"))),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        },
+        }),
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL 1 + 1 DAY";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval {
+        &Expr::Interval(Interval {
             value: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Value(number("1"))),
                 op: BinaryOperator::Plus,
@@ -3059,27 +3063,27 @@ fn parse_interval() {
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        },
+        }),
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '10' HOUR (1)";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval {
+        &Expr::Interval(Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: Some(1),
             last_field: None,
             fractional_seconds_precision: None,
-        },
+        }),
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '1 DAY'";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval {
+        &Expr::Interval(Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
                 "1 DAY"
             )))),
@@ -3087,7 +3091,7 @@ fn parse_interval() {
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        },
+        }),
         expr_from_projection(only(&select.projection)),
     );
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2986,20 +2986,20 @@ fn parse_interval() {
     let sql = "SELECT INTERVAL '1-1' YEAR TO MONTH";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1-1")))),
             leading_field: Some(DateTimeField::Year),
             leading_precision: None,
             last_field: Some(DateTimeField::Month),
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '01:01.01' MINUTE (5) TO SECOND (5)";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
                 "01:01.01"
             )))),
@@ -3007,53 +3007,53 @@ fn parse_interval() {
             leading_precision: Some(5),
             last_field: Some(DateTimeField::Second),
             fractional_seconds_precision: Some(5),
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '1' SECOND (5, 4)";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1")))),
             leading_field: Some(DateTimeField::Second),
             leading_precision: Some(5),
             last_field: None,
             fractional_seconds_precision: Some(4),
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '10' HOUR";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL 5 DAY";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(number("5"))),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL 1 + 1 DAY";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Value(number("1"))),
                 op: BinaryOperator::Plus,
@@ -3063,27 +3063,27 @@ fn parse_interval() {
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '10' HOUR (1)";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: Some(1),
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '1 DAY'";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
                 "1 DAY"
             )))),
@@ -3091,7 +3091,7 @@ fn parse_interval() {
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 


### PR DESCRIPTION
# Support INTERVAL Inside Window Frames

****Which issue does this PR close?****

We have added `INTERVAL` support inside window frames. Now [sqlparser](https://github.com/sqlparser-rs/sqlparser-rs) can parse queries such as 

```sql
SELECT 
COUNT(*) OVER (ORDER BY ts RANGE BETWEEN  INTERVAL '1 DAY' PRECEDING AND INTERVAL '1 DAY' FOLLOWING) 
FROM t;
```

This PR closes the following [issue](https://github.com/sqlparser-rs/sqlparser-rs/issues/631). 

**The** ****Rationale for this change****

[Datafusion](https://github.com/synnada-ai/arrow-datafusion) now supports window frame queries with [this merge](https://github.com/apache/arrow-datafusion/pull/3570).  However, since window frame bound only accepts u64 values we cannot run queries like the above on Datafusion. If this PR merges, after some minor changes we would be able to run `RANGE` queries involving `INTERVAL`s using Datafusion. In the roadmap of Datafusion there is a [plan](https://github.com/apache/arrow-datafusion/issues/3571) to support different types for `WindowFrameBound`.
